### PR TITLE
WL-3786 Don’t log when a user can’t be found.

### DIFF
--- a/chat-tool/tool/src/java/org/sakaiproject/chat2/tool/ChatTool.java
+++ b/chat-tool/tool/src/java/org/sakaiproject/chat2/tool/ChatTool.java
@@ -1538,7 +1538,8 @@ public class ChatTool implements RoomObserver, PresenceObserver {
       try {
          sender = UserDirectoryService.getUser(message.getOwner());
       } catch(UserNotDefinedException e) {
-         logger.error(e);
+          // Expected some users will get deleted.
+         logger.debug("Failed to find user for ID: "+ message.getOwner(), e);
          return message.getOwner();
       }
       return sender.getDisplayName();


### PR DESCRIPTION
If a user can’t be found because they are no longer a member of the institution then falling back to their ID acceptable and we don’t need to log an error for this.
